### PR TITLE
Automate PR creation from release to main branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,69 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+  # PR automático de release a staging (ya implementado)
+  create-pr-release-to-staging:
+    name: Create PR from release to Staging
+    runs-on: ubuntu-latest
+    needs: run_ci_on_release_branch
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_version }}
+      - name: Create Pull Request to Staging
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: prepare Staging merge for ${{ inputs.release_version }}"
+          title: "Release ${{ inputs.release_version }} → Staging"
+          body: |
+            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `staging`.
+            Por favor, revisa y aprueba según la política de revisores.
+          base: staging
+          branch: ${{ inputs.release_version }}
+
+  # PR automático de release a main
+  create-pr-release-to-main:
+    name: Create PR from release to Main
+    runs-on: ubuntu-latest
+    needs: run_ci_on_release_branch
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_version }}
+      - name: Create Pull Request to Main
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: prepare Main merge for ${{ inputs.release_version }}"
+          title: "Release ${{ inputs.release_version }} → Main"
+          body: |
+            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `main`.
+            Por favor, revisa y aprueba según la política de revisores.
+          base: main
+          branch: ${{ inputs.release_version }}
+
+  # PR automático de release a develop
+  create-pr-release-to-develop:
+    name: Create PR from release to Develop
+    runs-on: ubuntu-latest
+    needs: run_ci_on_release_branch
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_version }}
+      - name: Create Pull Request to Develop
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: prepare Develop merge for ${{ inputs.release_version }}"
+          title: "Release ${{ inputs.release_version }} → Develop"
+          body: |
+            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `develop`.
+            Por favor, revisa y aprueba según la política de revisores.
+          base: develop
+          branch: ${{ inputs.release_version }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-  # PR automático de release a staging (ya implementado)
+  # PR automático de release a staging (definido en este workflow)
   create-pr-release-to-staging:
     name: Create PR from release to Staging
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds GitHub Actions jobs to automatically create pull requests from the release branch to staging, main, and develop branches using the peter-evans/create-pull-request action. This streamlines the release process and ensures consistent PR creation for merging release changes into key branches.