### PR TITLE
Refactor release PR creation to use github-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,27 +107,34 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-  # PR automático de release a staging (definido en este workflow)
+  # PR automático de release a staging
   create-pr-release-to-staging:
     name: Create PR from release to Staging
     runs-on: ubuntu-latest
     needs: run_ci_on_release_branch
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_version }}
       - name: Create Pull Request to Staging
-        uses: peter-evans/create-pull-request@v6
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: prepare Staging merge for ${{ inputs.release_version }}"
-          title: "Release ${{ inputs.release_version }} → Staging"
-          body: |
-            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `staging`.
-            Por favor, revisa y aprueba según la política de revisores.
-          base: staging
-          branch: ${{ inputs.release_version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const { data: pr } = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Release ${{ inputs.release_version }} → Staging",
+                head: "${{ inputs.release_version }}",
+                base: "staging",
+                body: `Este PR fue generado automáticamente para solicitar el merge de la rama de release \`${{ inputs.release_version }}\` hacia \`staging\`. Por favor, revisa y aprueba según la política de revisores.`
+              });
+              core.info(`PR creado: ${pr.html_url}`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.info('Ya existe un PR abierto para esta rama.');
+              } else {
+                throw e;
+              }
+            }
 
   # PR automático de release a main
   create-pr-release-to-main:
@@ -135,21 +142,28 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_ci_on_release_branch
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_version }}
       - name: Create Pull Request to Main
-        uses: peter-evans/create-pull-request@v6
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: prepare Main merge for ${{ inputs.release_version }}"
-          title: "Release ${{ inputs.release_version }} → Main"
-          body: |
-            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `main`.
-            Por favor, revisa y aprueba según la política de revisores.
-          base: main
-          branch: ${{ inputs.release_version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const { data: pr } = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Release ${{ inputs.release_version }} → Main",
+                head: "${{ inputs.release_version }}",
+                base: "main",
+                body: `Este PR fue generado automáticamente para solicitar el merge de la rama de release \`${{ inputs.release_version }}\` hacia \`main\`. Por favor, revisa y aprueba según la política de revisores.`
+              });
+              core.info(`PR creado: ${pr.html_url}`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.info('Ya existe un PR abierto para esta rama.');
+              } else {
+                throw e;
+              }
+            }
 
   # PR automático de release a develop
   create-pr-release-to-develop:
@@ -157,19 +171,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_ci_on_release_branch
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_version }}
       - name: Create Pull Request to Develop
-        uses: peter-evans/create-pull-request@v6
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: prepare Develop merge for ${{ inputs.release_version }}"
-          title: "Release ${{ inputs.release_version }} → Develop"
-          body: |
-            Este PR fue generado automáticamente para solicitar el merge de la rama de release `${{ inputs.release_version }}` hacia `develop`.
-            Por favor, revisa y aprueba según la política de revisores.
-          base: develop
-          branch: ${{ inputs.release_version }}
-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const { data: pr } = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Release ${{ inputs.release_version }} → Develop",
+                head: "${{ inputs.release_version }}",
+                base: "develop",
+                body: `Este PR fue generado automáticamente para solicitar el merge de la rama de release \`${{ inputs.release_version }}\` hacia \`develop\`. Por favor, revisa y aprueba según la política de revisores.`
+              });
+              core.info(`PR creado: ${pr.html_url}`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.info('Ya existe un PR abierto para esta rama.');
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
Replaces the peter-evans/create-pull-request action with actions/github-script for creating automatic PRs from release branches to staging, main, and develop. This change provides more control over PR creation and handles the case where a PR already exists for the branch.