### PR TITLE
Compile TypeScript before running copy-robots script

### DIFF
--- a/.github/workflows/manual-copy-robots.yml
+++ b/.github/workflows/manual-copy-robots.yml
@@ -24,9 +24,12 @@ jobs:
         working-directory: app
       - name: Set environment variable
         run: echo "VERCEL_ENV=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
+      - name: Compile scripts (como en prebuild)
+        run: npx tsc --project scripts/tsconfig.json
+        working-directory: app
       - name: Run copy-robots script and append timestamp
         run: |
-          node scripts/copy-robots.js
+          node scripts/build/copy-robots.js
           if [ -f public/robots.txt ]; then
             echo "# Copied at $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> public/robots.txt
             echo "Timestamp appended to robots.txt"


### PR DESCRIPTION
Adds a step to compile TypeScript scripts before executing the copy-robots script in the workflow. Updates the script path to use the compiled JavaScript output.